### PR TITLE
Don't sort config. Respect the original order

### DIFF
--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed | comment }}
 ---
-{{ netplan_conf | from_yaml | to_nice_yaml(indent=2) }}
+{{ netplan_conf | from_yaml | to_nice_yaml(indent=2,sort_keys=False) }}


### PR DESCRIPTION
while testing the role I realized if I define this varible:

```
netplan_conf: |
  network:
    version: {{ netplan_version }}
    renderer: {{ netplan_renderer }}
    ethernets:
      eth0:
        addresses:
        - 10.34.46.100/24
      ens19:
        addresses:
        - 192.168.2.2/24
      ens20:
        addresses:
        - 192.168.3.2/24
```

I get this config (different order)

```
network:
  ethernets:
    ens19:
      addresses:
      - 192.168.2.2/24
    ens20:
      addresses:
      - 192.168.3.2/24
    eth0:
      addresses:
      - 10.34.46.100/24
  renderer: networkd
  version: 2
```

With this PR the generated config respects the same order defined in the ansible var e.g.

```
#
# Ansible managed
#
---
network:
  version: 2
  renderer: networkd
  ethernets:
    eth0:
      addresses:
      - 10.34.46.100/24
    ens19:
      addresses:
      - 192.168.2.2/24
    ens20:
      addresses:
      - 192.168.3.2/24
```
